### PR TITLE
fixed subprocess commands

### DIFF
--- a/prospr/hhblits.py
+++ b/prospr/hhblits.py
@@ -68,10 +68,8 @@ class BlitsAndPottsRunner(threading.Thread):
         subprocess.run(hhblitsCommand)
 
         print("[%s] hhblits completed." % datetime.now())
-        hhmakeCommand = hmake + \
-         " -i " + a3mf + \
-         " -o " + hhmf
         print("[%s] hhmake running." % datetime.now())
+        hhmakeCommand = [hmake, '-i', a3mf, '-o', hhmf]
         subprocess.run(hhmakeCommand)
         print("[%s] hhmake completed." % datetime.now())
 
@@ -79,8 +77,9 @@ class BlitsAndPottsRunner(threading.Thread):
             print("[%s] potts running." % datetime.now())
             a2mf = s.out_dir + s.domain + ".a2m"
             matf = s.out_dir + s.domain + ".mat"
-            reformatCmd = "/hh-suite/scripts/reformat.pl " + \
-                a3mf + " " + a2mf
+            reformatCmd = ["/hh-suite/scripts/reformat.pl", a3mf, a2mf]
+            subprocess.run(reformatCmd)
+
             import plmDCA_asymmetric
             plmDCA_asymmetric.initialize_runtime(["-nodisplay"])
             p = plmDCA_asymmetric.initialize()


### PR DESCRIPTION
I had some issues with generating HHblits profiles. 
- subprocess.run()
This method gets a list as the default argument. To use a command in a string, an optional argument, shell=True, is needed, but it is not recommended by Python due to a security issue, as far as I know.
- Conversion from A3M to A2M is missing
I guess running reformat.pl is missing for generating A2M formatted MSA file, which is an input for plmDCA.